### PR TITLE
Add ability to handle groups

### DIFF
--- a/src/xelery/core.clj
+++ b/src/xelery/core.clj
@@ -138,7 +138,9 @@
 
 (defn read-element [eld]
   (let [m {:name (.getName eld)}]
-    (type-def m (.getTypeDefinition eld))))
+    (if (instance?  com.sun.org.apache.xerces.internal.impl.xs.XSModelGroupImpl eld)
+      (assoc m :type :complex :elements (model-group-elements eld))
+      (type-def m (.getTypeDefinition eld)))))
 
 (defn schema-element [x]
   "Returns element definition of the root element of the schema file"
@@ -148,6 +150,4 @@
 
 (defn parse-resource [r] (schema-element (File. (resource-location r))))
 (defn print-sample [] (clojure.pprint/pprint (parse-resource "schema1.xsd")))
-
-
 


### PR DESCRIPTION
I tried parsing an xsd that contains a group in it. Before this change I would get an error, but now everything seems to process correctly.

I also, have one more potential PR but wasn't sure how you want to handle the situation. Some of the xsd files I have to parse only contain type definitions and no element definitions. Right now this throws an error. I think ideally it wouldn't. I'm not sure if it should return `nil` or maybe `{}`. What are your thoughts?

Thanks for the great library.