### PR TITLE
Stopped a NullPointerException from being thrown when no elements.

### DIFF
--- a/src/xelery/core.clj
+++ b/src/xelery/core.clj
@@ -145,7 +145,7 @@
 (defn schema-element [x]
   "Returns element definition of the root element of the schema file"
   (if-let [schema (read-schema x)]
-    (-> schema components first read-element)
+    (some-> schema components first read-element)
     (do (log (str "Parsing " (class x) " returned nil")))))
 
 (defn parse-resource [r] (schema-element (File. (resource-location r))))


### PR DESCRIPTION
Some people use a file just to hold types to use in other files, without defining any elements. This makes it so those files return nil instead of throwing an exception.