### PR TITLE
Added ability to grab documentation for an element.

### DIFF
--- a/test/schema1.xsd
+++ b/test/schema1.xsd
@@ -35,6 +35,11 @@
        </xs:sequence>
    </xs:complexType>
    <xs:simpleType name="nameType" >
+      <xs:annotation>
+           <xs:documentation>
+               A Name Type
+           </xs:documentation>
+       </xs:annotation>
        <xs:restriction base="xs:string">
            <xs:pattern value="[a-zA-z ]{1,50}"/>
        </xs:restriction>

--- a/test/xelery/core_test.clj
+++ b/test/xelery/core_test.clj
@@ -21,9 +21,9 @@
 
         { :name "cv",
          :type :complex,
-         :elements [{:name "firstName", :type :string, :typeName "nameType",
+         :elements [{:name "firstName", :type :string, :typeName "nameType", :documentation "A Name Type",
                      :facets {:whitespace "preserve"}, :pattern "[a-zA-z ]{1,50}", :multiplicity [1 1]}
-                    {:name "secondName", :type :string, :typeName "nameType",
+                    {:name "secondName", :type :string, :typeName "nameType", :documentation "A Name Type",
                      :facets {:whitespace "preserve"}, :pattern "[a-zA-z ]{1,50}", :multiplicity [1 1]}
                     {:name "sex", :type :enum, :typeName "sexType", :facets {:whitespace "preserve"}, :enumvals #{"M" "F"}, :multiplicity [1 1]}
                     {:name "freeText", :type :string, :multiplicity [0 3]}


### PR DESCRIPTION
Using `xs:documentation` you can add documentation to your schema. This extracts that documentation. See https://www.w3schools.com/xml/el_annotation.asp for an example of `xs:documentation` in use.